### PR TITLE
Pulse meter min update

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <vector>
-
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/component.h"
 #include "esphome/core/hal.h"
@@ -56,7 +54,7 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   volatile bool has_detected_edge_ = false;
   volatile bool has_valid_high_edge_ = false;
   volatile bool has_valid_low_edge_ = false;
-  std::vector<float> measurements_;
+  MovingAverage<float> mv_ {0.0f};
 };
 
 }  // namespace pulse_meter

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -496,6 +496,31 @@ template<typename T> class Deduplicator {
   T last_value_{};
 };
 
+/// Helper class to compute a moving average of numeric type \p T.
+template<typename T> class MovingAverage {
+ public:
+  explicit MovingAverage(T initial): wma_(initial), initial_(initial) {}
+
+  MovingAverage& operator +=(T v) {
+    // compute cumulative moving average
+    wma_ += (v - wma_) / ++cnt_;
+    return *this;
+  }
+
+  T operator *() const noexcept { return wma_; }
+  operator T() const noexcept { return wma_; }
+
+  /// Returns whether this moving average has processed any items so far.
+  bool has_value() const { return cnt_ > 0; }
+
+  /// Resets the moving average to initial value.
+  void reset() { wma_ = initial_; cnt_ = 0; }
+
+  private:
+    T wma_, initial_;
+    size_t cnt_ { 0 };
+};
+
 /// Helper class to easily give an object a parent of type \p T.
 template<typename T> class Parented {
  public:


### PR DESCRIPTION
Remove `std::vector` and replace by a cumulative average method to avoid allocations and reduce memory footprint.